### PR TITLE
Fix script paths and add fallback when removing backgrounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ cd logistica-remove_image_bg
 ./run.sh path/to/photo.jpg
 # → output.png generated in the same folder
 ```
+`run.sh` automatically activates the local virtual environment if it exists,
+so it can be invoked from any directory.
 
 You can also run directly:
 

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import sys
+import shutil
 from rembg import remove, new_session
 from PIL import Image
 import io
@@ -14,20 +15,25 @@ def main():
     with open(input_path, "rb") as input_file:
         input_data = input_file.read()
 
-    session = new_session("isnet-general-use")
+    try:
+        session = new_session("isnet-general-use")
 
-    result = remove(
-        input_data,
-        session=session,
-        alpha_matting=False,
-        only_mask=False,
-        post_process_mask=False
-    )
+        result = remove(
+            input_data,
+            session=session,
+            alpha_matting=False,
+            only_mask=False,
+            post_process_mask=False
+        )
 
-    with open(output_path, "wb") as output_file:
-        output_file.write(result)
+        with open(output_path, "wb") as output_file:
+            output_file.write(result)
 
-    print(f"Transparent background saved to {output_path}")
+        print(f"Transparent background saved to {output_path}")
+    except Exception as e:
+        print(f"Background removal failed: {e}\nUsing original image instead.")
+        shutil.copy(input_path, output_path)
+        print(f"Original image copied to {output_path}")
 
 if __name__ == "__main__":
     main()

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,12 @@
 #!/bin/bash
-source .venv/bin/activate
-python main.py "$1"
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+if [ -f ".venv/bin/activate" ]; then
+    # Activate virtual environment if it exists
+    source .venv/bin/activate
+fi
+
+python3 main.py "$1"


### PR DESCRIPTION
## Summary
- handle errors in `main.py` and fall back to copying the image if removal fails
- make `run.sh` robust to being launched from any directory
- mention automatic venv activation in `README`

## Testing
- `python3 -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_b_6843a304e34c8323b80be0b27f299bc8